### PR TITLE
Import PagerDuty module

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "concentrate":          "~0.2.2",
         "dissolve":             "~0.3.1",
         "campfire":             "~0.1.1",
-        "pagerduty":            "~0.0.3",
+        "request":              "~2.9.3",
         "temp":                 "~0.5.0"
     },
     "bin": {

--- a/src/lib/pagerduty.coffee
+++ b/src/lib/pagerduty.coffee
@@ -1,0 +1,40 @@
+# Based on https://github.com/Skomski/node-pagerduty
+request = require 'request'
+
+class PagerDuty
+  module.exports = PagerDuty
+
+  constructor: ({@serviceKey}) ->
+    return
+
+  create: ({description, incidentKey, details, callback}) ->
+    @_request arguments[0] extends eventType: 'trigger'
+
+  acknowledge: ({incidentKey, details, description, callback}) ->
+    @_request arguments[0] extends eventType: 'acknowledge'
+
+  resolve: ({incidentKey, details, description, callback}) ->
+    @_request arguments[0] extends eventType: 'resolve'
+
+  _request: ({description, incidentKey, eventType, details, callback}) ->
+    incidentKey ||= null
+    details     ||= {}
+    callback    ||= ->
+
+    json =
+      service_key: @serviceKey
+      event_type: eventType
+      description: description
+      details: details
+
+    json.incident_key = incidentKey
+
+    request
+      method: 'POST'
+      uri: 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+      json: json
+    , (err, response, body) ->
+      if err or response.statusCode != 200
+        callback err || new Error(body.errors[0])
+      else
+        callback null, body

--- a/src/streammachine/alerts.coffee
+++ b/src/streammachine/alerts.coffee
@@ -1,7 +1,7 @@
 nconf       = require "nconf"
 _u          = require "underscore"
 nodemailer  = require "nodemailer"
-pagerduty   = require "pagerduty"
+pagerduty   = require "../lib/pagerduty"
 
 
 ALERT_TYPES = 
@@ -198,7 +198,7 @@ module.exports = class Alerts extends require("events").EventEmitter
                 details     : details
 
                 callback: (error, response) =>
-                    if response.incident_key
+                    if response && response.incident_key
                         @incidentKeys[details.key] = response.incident_key
                     else
                         @alerts.logger.error "PagerDuty response did not include an incident key.", response:response


### PR DESCRIPTION
Fixes #13

* Remove dependency on PagerDuty package
* Removes the error throwing in PagerDuty

With your updates plus this, it shouldn't be throwing errors anymore. I don't fully understand why the incident key is missing sometimes — maybe the master instance of streammachine is dying, which would remove those keys from memory. Just a guess.