### PR TITLE
W3C logger updates

### DIFF
--- a/src/streammachine/logger/index.coffee
+++ b/src/streammachine/logger/index.coffee
@@ -210,11 +210,6 @@ module.exports = class LogController
         #----------
         
         open: (cb) ->
-            # If the directory for the w3c file doesn't exist, don't try to
-            # open it.
-            if !f.existsSync(path.dirname(@options.filename))
-                return false
-
             if @_opening
                 console.log "W3C already opening... wait."
                 # we're already trying to open.  return an error so we queue the message
@@ -241,7 +236,7 @@ module.exports = class LogController
                     @_opening = null
                     cb?()
                 
-                if not fs.statSync(@options.filename).size > 0
+                if fs.statSync(@options.filename).size == 0
                     # write our initial w3c lines before we return
                     @_file.write "#Software: StreamMachine\n#Version: 0.2.9\n#Fields: c-ip date time cs-uri-stem c-status cs(User-Agent) sc-bytes x-duration\n", "utf8", =>
                         _clear()


### PR DESCRIPTION
* Open log file in 'a' mode every time, which will create it if it
  doesn't exist, and append to it if it does exist. Previously it was
  overwriting the file if it existed when master was restarted ('w' mode).
* Protects against the case where the path leading up to the log file
  doesn't exist, which would cause the entire app to crash. I'm open to
  finding a better way to handle this than what I have here.