### PR TITLE
Adding analytics log transport broken in standalone mode

### DIFF
--- a/src/streammachine/logger/index.coffee
+++ b/src/streammachine/logger/index.coffee
@@ -92,6 +92,7 @@ module.exports = class LogController
 
                     @parent[k].apply @, args
 
+            @logger = @parent.logger
             @child = (opts={}) -> new LogController.Child(@parent,_u.extend({},@opts,opts))
 
         proxyToMaster: (sock) ->


### PR DESCRIPTION
```LogController.Child``` is missing the ```logger``` property that points to an existing ```winston.Logger``` instance. This breaks adding ```Analytics.LogTransport``` if analytics is enabled in standalone mode.

I simply added it to the child logger as a reference to parent's ```logger``` to keep the interface consistent.


