### PR TITLE
Fix for optional argument cb in standalone mode

### DIFF
--- a/src/streammachine/modes/standalone.coffee
+++ b/src/streammachine/modes/standalone.coffee
@@ -61,7 +61,7 @@ module.exports = class StandaloneMode extends require("./base")
 
         @log.debug "Standalone is listening on port #{@opts.port}"
 
-        cb null, @
+        cb? null, @
 
     #----------
 


### PR DESCRIPTION
Once again: standalone mode ;) 
```cb``` is only available in tests so it should be optional.