### PR TITLE
Update ES schema creation

### DIFF
--- a/js/src/streammachine/analytics/es_templates.js
+++ b/js/src/streammachine/analytics/es_templates.js
@@ -74,12 +74,6 @@ module.exports = {
           },
           kbytes: {
             type: "long"
-          },
-          ips: {
-            type: "string",
-            index: "not_analyzed",
-            copy_to: "ip",
-            doc_values: true
           }
         })
       }


### PR DESCRIPTION
Update Schema creation to be compatible with ES > 2, index_name was deprecated and give error.
Reference: elastic/elasticsearch#11079